### PR TITLE
Update matplotlib.py to use .get_next_color

### DIFF
--- a/src/hapsira/plotting/orbit/backends/matplotlib.py
+++ b/src/hapsira/plotting/orbit/backends/matplotlib.py
@@ -69,8 +69,12 @@ class Matplotlib2D(OrbitPlotterBackend):
 
         """
         if color is None:
-            # HACK: https://stackoverflow.com/a/13831816/554319
-            color = next(self.ax._get_lines.prop_cycler)["color"]
+            try:
+                # Updated HACK, see https://stackoverflow.com/a/78938755
+                color = ax._get_lines.get_next_color()
+            except AttributeError:
+                # HACK: https://stackoverflow.com/a/13831816/554319
+                color = next(self.ax._get_lines.prop_cycler)["color"]
 
         colors = [color, to_rgba(color, 0)] if trail else [color]
         return colors

--- a/src/hapsira/plotting/orbit/backends/matplotlib.py
+++ b/src/hapsira/plotting/orbit/backends/matplotlib.py
@@ -71,7 +71,7 @@ class Matplotlib2D(OrbitPlotterBackend):
         if color is None:
             try:
                 # Updated HACK, see https://stackoverflow.com/a/78938755
-                color = ax._get_lines.get_next_color()
+                color = self.ax._get_lines.get_next_color()
             except AttributeError:
                 # HACK: https://stackoverflow.com/a/13831816/554319
                 color = next(self.ax._get_lines.prop_cycler)["color"]


### PR DESCRIPTION
At some point between matplotlib 3.7 and 3.9, ax._get_lines.prop_cycler was removed. The recommended replacement (per https://stackoverflow.com/a/78938755) is to use ax._get_lines.get_next_color(). Implemented with a try/except to hopefully support both.

This addresses Issue #14 

<!-- readthedocs-preview hapsira start -->
----
📚 Documentation preview 📚: https://hapsira--15.org.readthedocs.build/en/15/

<!-- readthedocs-preview hapsira end -->